### PR TITLE
fix(types): add mts types declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
   "exports": {
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs",
-    "types": "./dist/index.d.ts"
+    "types": {
+      "import": "./dist/index.d.mts",
+      "require": "./dist/index.d.ts"
+    }
   },
   "main": "./dist/index.cjs",
   "unpkg": "./dist/index.umd.js",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -81,6 +81,14 @@ const rollupOptions: readonly RollupOptions[] = [
     },
     plugins: [dts()],
   },
+  {
+    input: 'build/dts/index.d.ts',
+    output: {
+      dir: outputDir,
+      entryFileNames: '[name].mts',
+    },
+    plugins: [dts()],
+  },
 ]
 
 export default rollupOptions


### PR DESCRIPTION
When using Typescript, importing this package ends up resolving to `index.d.ts`. Typescript sees this as a commonjs file because the closest `package.json` is not `"type": "module"`. Typescript is not smart enough to realize the _actual_ import is ESM and handle it as such.

As a result, Typescript tries to outsmart the user and add proper handling from the `default` export.
i.e. try overriding your package.json to 
```
"exports": {
    ".": "./dist/index.cjs"
}
```
and then running 
`console.log(import('didyourmean2'))` to see what Typescript _thinks_ is happening.

In reality though, the import resolves to an actual ESM file which properly handles the default export. So we just need to have the types declared as such.

My approach is to re-publish the same types with under a `.d.mts` extension so typescript knows exactly what type of file is being imported, and doesn't attempt any default trickery.