### PR TITLE
fix(deps): remove unnecessary dependency on @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "*.md"
   ],
   "scripts": {
-    "build": "yarn clean:build && tsc --project tsconfig.build.json && rollup --configPlugin \"babel={ babelHelpers: 'runtime', extensions: ['.js', '.ts'] }\" -c",
+    "build": "yarn clean:build && tsc --project tsconfig.build.json && rollup --configPlugin \"babel={ extensions: ['.js', '.ts'] }\" -c",
     "ci": "yarn build && npm-run-all -p 'lint:*' 'type:*' && yarn test && size-limit",
     "clean:build": "shx rm -rf dist/ build/dts/",
     "lint": "npm-run-all -p 'lint:*'",
@@ -64,7 +64,6 @@
     "type:coverage": "type-coverage --strict --at-least 99 --detail --ignore-catch"
   },
   "dependencies": {
-    "@babel/runtime": "^7.24.8",
     "fastest-levenshtein": "^1.0.16",
     "lodash.deburr": "^4.1.0"
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -33,7 +33,6 @@ const rollupOptions: readonly RollupOptions[] = [
     ],
     plugins: [
       babel({
-        babelHelpers: 'runtime',
         extensions: ['.js', '.ts'],
       }),
       commonjs({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,7 +1375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.24.8, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.8.4":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -4507,7 +4507,6 @@ __metadata:
   resolution: "didyoumean2@workspace:."
   dependencies:
     "@babel/core": "npm:7.26.0"
-    "@babel/runtime": "npm:^7.24.8"
     "@commitlint/cli": "npm:19.6.1"
     "@commitlint/config-conventional": "npm:19.6.0"
     "@foray1010/babel-preset": "npm:10.0.0"


### PR DESCRIPTION
After investigating the output bundle, it became apparent that at this moment, @babel/runtime serves no purpose. Therefore, I removed it from dependencies, thus reducing didyoumean2 install footprint by over 70% (378 KB -> 108 KB).